### PR TITLE
引用符のせいで動かない

### DIFF
--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -6,13 +6,17 @@ module.exports =
     path = @safeBroker()
     return unless path?
 
-    @execFile Config.get.compilerPath(),Config.get.runCommand()
+    # @execFile Config.get.compilerPath(),Config.get.runCommand()
+    command = (Config.get.compilerPath() + " " + Config.get.runCommand().join(' ')).replace(/\""/g, "")
+    @exec command
 
   make: ->
     path = @safeBroker()
     return unless path?
 
-    @execFile Config.get.compilerPath(),Config.get.makeCommand()
+    # @execFile Config.get.compilerPath(),Config.get.makeCommand()
+    command = (Config.get.compilerPath() + " " + Config.get.makeCommand().join(' ')).replace(/\""/g, "")
+    @exec command
 
   safeBroker: ->
     editor = atom.workspace.getActiveTextEditor()
@@ -35,6 +39,26 @@ module.exports =
     require('child_process').execFile(
       filePath,
       commands,
+      {
+        encoding: Config.get.compilerEncoding()
+        maxBuffer: Config.get.maxLogBuffer()
+      },
+      (err, stdout, stderr) ->
+        option =
+          detail: require('./submodel').convertToUTF8(stdout)
+        if err
+          option.dismissable = true
+          atom.notifications.addError "Error (language-hsp3)", option
+        else
+          option.dismissable = Config.get.keepShowSuccessMessage()
+          atom.notifications.addSuccess "Success (language-hsp3)", option
+        return
+    )
+    return
+
+  exec: (command) ->
+    require('child_process').exec(
+      command,
       {
         encoding: Config.get.compilerEncoding()
         maxBuffer: Config.get.maxLogBuffer()

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -7,7 +7,7 @@ module.exports =
     return unless path?
 
     # @execFile Config.get.compilerPath(),Config.get.runCommand()
-    command = (Config.get.compilerPath() + " " + Config.get.runCommand().join(' ')).replace(/\""/g, "")
+    command = (Config.get.compilerPath() + " " + Config.get.runCommand().join(' ').replace(/\""/g, ""))
     @exec command
 
   make: ->
@@ -15,7 +15,7 @@ module.exports =
     return unless path?
 
     # @execFile Config.get.compilerPath(),Config.get.makeCommand()
-    command = (Config.get.compilerPath() + " " + Config.get.makeCommand().join(' ')).replace(/\""/g, "")
+    command = (Config.get.compilerPath() + " " + Config.get.makeCommand().join(' ').replace(/\""/g, ""))
     @exec command
 
   safeBroker: ->


### PR DESCRIPTION
Node.jsのexecFile関数が上手いこと引数にクオーテーションをつけてきやがるので、私の環境で動きませんでした。hspc.exeのファイル名引数にクオーテーションが用いれないみたいなので、一時的な処置になってしまいますが、強制的にコマンドからクオーテーション削除して実行するようにしてみました。